### PR TITLE
Add WAF panels

### DIFF
--- a/ambassador.json
+++ b/ambassador.json
@@ -22,12 +22,13 @@
       }
     ]
   },
+  "description": "Ambassador Edge Stack dashboard for Prometheus",
   "editable": true,
+  "fiscalYearStartMonth": 0,
   "gnetId": 4698,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1533927661420,
   "links": [],
+  "liveNow": false,
   "panels": [
     {
       "collapsed": false,
@@ -40,18 +41,22 @@
       },
       "id": 34,
       "panels": [],
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "refId": "A"
+        }
+      ],
       "title": "Emissary-ingress Control Plane",
       "type": "row"
     },
     {
-      "cacheTimeout": null,
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "fixed"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -91,11 +96,11 @@
         "text": {},
         "textMode": "value"
       },
-      "pluginVersion": "7.4.3",
-      "repeat": null,
+      "pluginVersion": "9.4.7",
       "repeatDirection": "h",
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_diagnostics_info{namespace=~\"$namespace\"}",
           "format": "table",
           "hide": false,
@@ -106,8 +111,6 @@
           "refId": "A"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Version",
       "type": "stat"
     },
@@ -117,12 +120,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -152,7 +149,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -162,6 +159,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_process_resident_memory_bytes{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -170,9 +168,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Control plane memory",
       "tooltip": {
         "shared": true,
@@ -181,9 +177,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -193,23 +187,18 @@
           "format": "decbytes",
           "label": "Bytes",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:702",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -218,12 +207,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -253,7 +236,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -263,6 +246,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(ambassador_process_cpu_seconds_total{namespace=~\"^($namespace)$\",pod=~\"^($pod)$\"}[$__rate_interval])) by (pod)",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -271,9 +255,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Control plane cpu",
       "tooltip": {
         "shared": true,
@@ -282,9 +264,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -294,34 +274,27 @@
           "format": "s",
           "label": "Seconds",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:702",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
-      "cacheTimeout": null,
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "displayName": "${__series.name}",
           "mappings": [],
           "max": 2.5,
@@ -357,6 +330,8 @@
       "links": [],
       "options": {
         "displayMode": "lcd",
+        "minVizHeight": 10,
+        "minVizWidth": 0,
         "orientation": "auto",
         "reduceOptions": {
           "calcs": [
@@ -368,18 +343,12 @@
         "showUnfilled": true,
         "text": {}
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "repeat": "pod",
       "repeatDirection": "v",
-      "scopedVars": {
-        "pod": {
-          "selected": false,
-          "text": "edge-stack-755cb8b774-42h7w",
-          "value": "edge-stack-755cb8b774-42h7w"
-        }
-      },
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_reconfiguration_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "hide": false,
           "instant": false,
@@ -387,258 +356,41 @@
           "refId": "C"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_fetcher_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "instant": false,
           "legendFormat": "Fetcher",
           "refId": "E"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_aconf_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "instant": false,
           "legendFormat": "AConf",
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_ir_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "instant": false,
           "legendFormat": "IR",
           "refId": "F"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_econf_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "instant": false,
           "legendFormat": "EConf",
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_diagnostics_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "instant": false,
           "legendFormat": "Diagnostics",
           "refId": "D"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Last control plane operation time ($pod)",
-      "type": "bargauge"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {},
-          "displayName": "${__series.name}",
-          "mappings": [],
-          "max": 2.5,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 15
-      },
-      "id": 84,
-      "links": [],
-      "options": {
-        "displayMode": "lcd",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "text": {}
-      },
-      "pluginVersion": "7.4.3",
-      "repeatDirection": "v",
-      "repeatIteration": 1664458904583,
-      "repeatPanelId": 42,
-      "scopedVars": {
-        "pod": {
-          "selected": false,
-          "text": "edge-stack-755cb8b774-bq52q",
-          "value": "edge-stack-755cb8b774-bq52q"
-        }
-      },
-      "targets": [
-        {
-          "expr": "ambassador_reconfiguration_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Reconfiguration",
-          "refId": "C"
-        },
-        {
-          "expr": "ambassador_fetcher_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "Fetcher",
-          "refId": "E"
-        },
-        {
-          "expr": "ambassador_aconf_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "AConf",
-          "refId": "A"
-        },
-        {
-          "expr": "ambassador_ir_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "IR",
-          "refId": "F"
-        },
-        {
-          "expr": "ambassador_econf_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "EConf",
-          "refId": "B"
-        },
-        {
-          "expr": "ambassador_diagnostics_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "Diagnostics",
-          "refId": "D"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Last control plane operation time ($pod)",
-      "type": "bargauge"
-    },
-    {
-      "cacheTimeout": null,
-      "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "custom": {},
-          "displayName": "${__series.name}",
-          "mappings": [],
-          "max": 2.5,
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "#EAB839",
-                "value": 1
-              },
-              {
-                "color": "red",
-                "value": 2
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 5,
-        "w": 24,
-        "x": 0,
-        "y": 20
-      },
-      "id": 85,
-      "links": [],
-      "options": {
-        "displayMode": "lcd",
-        "orientation": "auto",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true,
-        "text": {}
-      },
-      "pluginVersion": "7.4.3",
-      "repeatDirection": "v",
-      "repeatIteration": 1664458904583,
-      "repeatPanelId": 42,
-      "scopedVars": {
-        "pod": {
-          "selected": false,
-          "text": "edge-stack-755cb8b774-j2wmq",
-          "value": "edge-stack-755cb8b774-j2wmq"
-        }
-      },
-      "targets": [
-        {
-          "expr": "ambassador_reconfiguration_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "hide": false,
-          "instant": false,
-          "legendFormat": "Reconfiguration",
-          "refId": "C"
-        },
-        {
-          "expr": "ambassador_fetcher_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "Fetcher",
-          "refId": "E"
-        },
-        {
-          "expr": "ambassador_aconf_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "AConf",
-          "refId": "A"
-        },
-        {
-          "expr": "ambassador_ir_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "IR",
-          "refId": "F"
-        },
-        {
-          "expr": "ambassador_econf_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "EConf",
-          "refId": "B"
-        },
-        {
-          "expr": "ambassador_diagnostics_time_seconds{namespace=~\"$namespace\", pod=~\"$pod\"}",
-          "instant": false,
-          "legendFormat": "Diagnostics",
-          "refId": "D"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Last control plane operation time ($pod)",
       "type": "bargauge"
     },
@@ -653,6 +405,12 @@
       },
       "id": 38,
       "panels": [],
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "refId": "A"
+        }
+      ],
       "title": "Ambassador Edge Stack",
       "type": "row"
     },
@@ -664,7 +422,6 @@
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -698,7 +455,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -708,6 +465,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": " ambassador_edge_stack_go_memstats_alloc_bytes{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -715,9 +473,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "amb-sidecar memory",
       "tooltip": {
         "shared": true,
@@ -726,9 +482,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -738,23 +492,18 @@
           "format": "decbytes",
           "label": "Bytes allocated",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:60",
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -765,7 +514,6 @@
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -799,7 +547,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -809,6 +557,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "rate(ambassador_edge_stack_process_cpu_seconds_total{namespace=~\"$namespace\", pod=~\"$pod\"}[$__rate_interval])",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -816,9 +565,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "amb-sidecar cpu",
       "tooltip": {
         "shared": true,
@@ -827,9 +574,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -839,23 +584,18 @@
           "format": "s",
           "label": "Seconds",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:60",
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -866,7 +606,6 @@
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -900,7 +639,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -910,6 +649,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "ambassador_edge_stack_go_goroutines{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -917,9 +657,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "amb-sidecar go-routines",
       "tooltip": {
         "shared": true,
@@ -928,9 +666,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -940,23 +676,18 @@
           "format": "none",
           "label": "Count",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:60",
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -965,12 +696,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1000,7 +725,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1010,6 +735,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_ext_authz_ok[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Allowed",
@@ -1017,6 +743,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_ext_authz_denied[$__rate_interval]))",
           "hide": false,
           "interval": "",
@@ -1025,6 +752,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_ext_authz_error[$__rate_interval]))",
           "hide": false,
           "interval": "",
@@ -1033,6 +761,7 @@
           "refId": "C"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_ext_authz_failure_mode_allowed[$__rate_interval]))",
           "hide": false,
           "interval": "",
@@ -1042,9 +771,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Auth requests",
       "tooltip": {
         "shared": true,
@@ -1053,9 +780,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1065,23 +790,18 @@
           "format": "short",
           "label": "Requests",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:220",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1090,12 +810,6 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "${DS_PROMETHEUS}",
-      "fieldConfig": {
-        "defaults": {
-          "custom": {}
-        },
-        "overrides": []
-      },
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
@@ -1126,7 +840,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1136,6 +850,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_ratelimit_ok[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Allowed",
@@ -1143,6 +858,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_ratelimit_over_limit[$__rate_interval]))",
           "hide": false,
           "interval": "",
@@ -1151,6 +867,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_ratelimit_error[$__rate_interval]))",
           "hide": false,
           "interval": "",
@@ -1159,6 +876,7 @@
           "refId": "C"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_ratelimit_failure_mode_allowed[$__rate_interval]))",
           "hide": false,
           "interval": "",
@@ -1168,9 +886,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Ratelimit requests",
       "tooltip": {
         "shared": true,
@@ -1179,9 +895,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1191,36 +905,314 @@
           "format": "short",
           "label": "Requests",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:220",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "Graph of allows and denials by Web Application Firewalls",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Per Minute",
+            "axisPlacement": "auto",
+            "axisSoftMax": 100,
+            "axisSoftMin": 1,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 7,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 0,
+        "y": 45
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum(increase(waf_allowed_breakdown_total[1m])) without (container, endpoint, instance, job, namespace, operation, otel_scope_name, otel_scope_version, pod, service, waf_name)",
+          "format": "time_series",
+          "legendFormat": "Allowed",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum(increase(waf_denied_breakdown_total{operation=\"request\"}[1m])) without (container, endpoint, instance, job, namespace, otel_scope_name, otel_scope_version, pod, service, status, waf_name)",
+          "format": "time_series",
+          "hide": false,
+          "legendFormat": "Denied on request",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum(increase(waf_denied_breakdown_total{operation=\"response\"}[1m])) without (container, endpoint, instance, job, namespace, otel_scope_name, otel_scope_version, pod, service, status, waf_name)",
+          "format": "time_series",
+          "legendFormat": "Denied on response",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "WAF Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "Keeps track of latency added to requests and responses by WAF processing.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "Time",
+            "axisPlacement": "auto",
+            "axisSoftMax": 100,
+            "axisSoftMin": 0,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 6,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 6,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 10,
+        "y": 45
+      },
+      "id": 87,
+      "options": {
+        "legend": {
+          "calcs": [
+            "min",
+            "max",
+            "last"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(waf_added_latency_ms_bucket{phase=~\"process_request_headers|write_request_body|process_request_body\"}[$__rate_interval])) by (le))",
+          "legendFormat": "Added request latency",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(waf_added_latency_ms_bucket{phase=~\"process_response_headers|write_response_body|process_response_body\"}[$__rate_interval])) by (le))",
+          "hide": false,
+          "legendFormat": "Added response latency",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "WAF Process Time",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "Number of WebApplicationFirewall resources loaded across all pods.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 20,
+        "y": 45
+      },
+      "id": 93,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.4.7",
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "editorMode": "code",
+          "expr": "sum(waf_created_wafs) without (container, endpoint, instance, job, namespace, operation, otel_scope_name, otel_scope_version, pod, service, waf_name)",
+          "format": "time_series",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Loaded WAFs",
+      "type": "stat"
+    },
+    {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 53
       },
       "id": 73,
       "panels": [],
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "refId": "A"
+        }
+      ],
       "title": "Envoy Data Plane",
       "type": "row"
     },
@@ -1231,7 +1223,6 @@
           "color": {
             "mode": "thresholds"
           },
-          "custom": {},
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
@@ -1245,7 +1236,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 46
+        "y": 54
       },
       "id": 75,
       "options": {
@@ -1263,9 +1254,10 @@
         "text": {},
         "textMode": "auto"
       },
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "envoy_server_uptime{namespace=~\"$namespace\",pod=~\"^($pod)$\"}",
           "format": "time_series",
           "instant": true,
@@ -1286,7 +1278,6 @@
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -1297,7 +1288,7 @@
         "h": 9,
         "w": 16,
         "x": 8,
-        "y": 46
+        "y": 54
       },
       "hiddenSeries": false,
       "id": 78,
@@ -1320,7 +1311,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1330,6 +1321,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": " envoy_server_memory_allocated{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "interval": "",
           "legendFormat": "{{pod}}",
@@ -1337,9 +1329,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Envoy memory",
       "tooltip": {
         "shared": true,
@@ -1348,9 +1338,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1360,23 +1348,18 @@
           "format": "decbytes",
           "label": "Bytes allocated",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:60",
           "format": "none",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": false
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1386,11 +1369,16 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 63
       },
       "id": 22,
       "panels": [],
-      "repeat": null,
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "refId": "A"
+        }
+      ],
       "title": "Envoy Downstream (from clients)",
       "type": "row"
     },
@@ -1402,7 +1390,6 @@
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -1413,7 +1400,7 @@
         "h": 12,
         "w": 8,
         "x": 0,
-        "y": 56
+        "y": 64
       },
       "hiddenSeries": false,
       "id": 30,
@@ -1437,7 +1424,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1447,6 +1434,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_rq_xx{envoy_response_code_class=\"2\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
@@ -1455,6 +1443,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_rq_xx{envoy_response_code_class=\"3\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
@@ -1463,6 +1452,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_rq_xx{envoy_response_code_class=\"4\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
@@ -1471,6 +1461,7 @@
           "refId": "C"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_rq_xx{envoy_response_code_class=\"5\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
@@ -1480,9 +1471,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Response codes (to clients)",
       "tooltip": {
         "shared": true,
@@ -1491,9 +1480,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1503,23 +1490,18 @@
           "format": "short",
           "label": "RPM",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:1678",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1530,7 +1512,6 @@
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -1541,7 +1522,7 @@
         "h": 12,
         "w": 8,
         "x": 8,
-        "y": 56
+        "y": 64
       },
       "hiddenSeries": false,
       "id": 45,
@@ -1565,7 +1546,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1575,6 +1556,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_rq_time_bucket[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
@@ -1584,6 +1566,7 @@
           "refId": "E"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.95, sum(rate(envoy_http_downstream_rq_time_bucket[$__rate_interval])) by (le))",
           "format": "time_series",
           "interval": "",
@@ -1592,6 +1575,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.9, sum(rate(envoy_http_downstream_rq_time_bucket[$__rate_interval])) by (le))",
           "format": "time_series",
           "interval": "",
@@ -1600,6 +1584,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.5, sum(rate(envoy_http_downstream_rq_time_bucket[$__rate_interval])) by (le))",
           "format": "time_series",
           "interval": "",
@@ -1609,9 +1594,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Request time",
       "tooltip": {
         "shared": true,
@@ -1620,9 +1603,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1632,23 +1613,18 @@
           "format": "ms",
           "label": "Time",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:345",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1659,7 +1635,6 @@
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
-          "custom": {},
           "links": []
         },
         "overrides": []
@@ -1670,7 +1645,7 @@
         "h": 12,
         "w": 8,
         "x": 16,
-        "y": 56
+        "y": 64
       },
       "hiddenSeries": false,
       "id": 61,
@@ -1694,7 +1669,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.4.3",
+      "pluginVersion": "9.4.7",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1704,6 +1679,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_rq_idle_timeout[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -1713,6 +1689,7 @@
           "refId": "E"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_rq_timeout[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -1722,6 +1699,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_rq_max_duration_reached[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -1731,6 +1709,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_rq_overload_close[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -1741,9 +1720,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Closed requests",
       "tooltip": {
         "shared": true,
@@ -1752,9 +1729,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1764,23 +1739,18 @@
           "format": "short",
           "label": "Number of requests",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:345",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1802,7 +1772,7 @@
         "h": 12,
         "w": 8,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "hiddenSeries": false,
       "id": 28,
@@ -1836,6 +1806,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(envoy_http_downstream_cx_http1_active)",
           "format": "time_series",
           "interval": "",
@@ -1844,6 +1815,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(envoy_http_downstream_cx_http2_active)",
           "format": "time_series",
           "interval": "",
@@ -1852,6 +1824,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(envoy_http_downstream_cx_http3_active)",
           "format": "time_series",
           "hide": false,
@@ -1861,6 +1834,7 @@
           "refId": "D"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(envoy_http_downstream_cx_upgrades_active)",
           "format": "time_series",
           "interval": "",
@@ -1870,9 +1844,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Active connections",
       "tooltip": {
         "shared": true,
@@ -1881,9 +1853,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -1893,23 +1863,18 @@
           "format": "short",
           "label": "Number of connections",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:398",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -1931,7 +1896,7 @@
         "h": 12,
         "w": 8,
         "x": 8,
-        "y": 68
+        "y": 76
       },
       "hiddenSeries": false,
       "id": 26,
@@ -1965,6 +1930,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.99, sum(rate(envoy_http_downstream_cx_length_ms_bucket[$__rate_interval])) by (le))",
           "format": "time_series",
           "hide": false,
@@ -1974,6 +1940,7 @@
           "refId": "D"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.95, sum(rate(envoy_http_downstream_cx_length_ms_bucket[$__rate_interval])) by (le))",
           "format": "time_series",
           "interval": "",
@@ -1982,6 +1949,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.9, sum(rate(envoy_http_downstream_cx_length_ms_bucket[$__rate_interval])) by (le))",
           "format": "time_series",
           "interval": "",
@@ -1990,6 +1958,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.5, sum(rate(envoy_http_downstream_cx_length_ms_bucket[$__rate_interval])) by (le))",
           "format": "time_series",
           "interval": "",
@@ -1999,9 +1968,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Connection length",
       "tooltip": {
         "shared": true,
@@ -2010,9 +1977,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2022,23 +1987,18 @@
           "format": "ms",
           "label": "Time",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:345",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2060,7 +2020,7 @@
         "h": 12,
         "w": 8,
         "x": 16,
-        "y": 68
+        "y": 76
       },
       "hiddenSeries": false,
       "id": 62,
@@ -2094,6 +2054,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_cx_drain_close[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -2103,6 +2064,7 @@
           "refId": "E"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_cx_idle_timeout[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -2112,6 +2074,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_cx_max_duration_reached[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -2121,6 +2084,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_cx_max_requests_reached[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -2130,6 +2094,7 @@
           "refId": "C"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_cx_destroy_remote[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -2139,6 +2104,7 @@
           "refId": "D"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_http_downstream_cx_destroy_local[$__rate_interval]))",
           "format": "time_series",
           "hide": false,
@@ -2149,9 +2115,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Closed connections",
       "tooltip": {
         "shared": true,
@@ -2160,9 +2124,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2172,41 +2134,41 @@
           "format": "short",
           "label": "Number of connections",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:345",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
       "collapsed": false,
-      "datasource": null,
+      "datasource": "${DS_PROMETHEUS}",
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 80
+        "y": 88
       },
       "id": 53,
       "panels": [],
+      "targets": [
+        {
+          "datasource": "${DS_PROMETHEUS}",
+          "refId": "A"
+        }
+      ],
       "title": "Envoy Upstream (to services)",
       "type": "row"
     },
     {
-      "cacheTimeout": null,
       "datasource": "${DS_PROMETHEUS}",
       "fieldConfig": {
         "defaults": {
@@ -2222,8 +2184,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "green",
-                "value": null
+                "color": "green"
               }
             ]
           },
@@ -2235,10 +2196,9 @@
         "h": 11,
         "w": 16,
         "x": 0,
-        "y": 81
+        "y": 89
       },
       "id": 32,
-      "interval": null,
       "links": [],
       "maxDataPoints": 100,
       "options": {
@@ -2255,9 +2215,9 @@
         "text": {}
       },
       "pluginVersion": "7.4.3",
-      "repeat": null,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "envoy_cluster_manager_active_clusters{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "format": "time_series",
           "instant": false,
@@ -2267,6 +2227,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "envoy_cluster_manager_warming_clusters{namespace=~\"$namespace\", pod=~\"$pod\"}",
           "format": "time_series",
           "hide": false,
@@ -2277,8 +2238,6 @@
           "refId": "B"
         }
       ],
-      "timeFrom": null,
-      "timeShift": null,
       "title": "Registered clusters",
       "type": "bargauge"
     },
@@ -2301,7 +2260,7 @@
         "h": 11,
         "w": 8,
         "x": 16,
-        "y": 81
+        "y": 89
       },
       "hiddenSeries": false,
       "id": 20,
@@ -2335,6 +2294,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class=\"2\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
@@ -2343,6 +2303,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class=\"3\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
@@ -2351,6 +2312,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class=\"4\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
@@ -2359,6 +2321,7 @@
           "refId": "C"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_rq_xx{envoy_response_code_class=\"5\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
@@ -2368,9 +2331,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Response codes (from services)",
       "tooltip": {
         "shared": true,
@@ -2379,9 +2340,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2391,23 +2350,18 @@
           "format": "short",
           "label": "RPM",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:3071",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2454,7 +2408,7 @@
         "h": 11,
         "w": 8,
         "x": 0,
-        "y": 92
+        "y": 100
       },
       "hiddenSeries": false,
       "id": 69,
@@ -2488,6 +2442,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.99, sum(rate(envoy_cluster_upstream_rq_time_bucket{}[$__rate_interval])) by (envoy_cluster_name, le))",
           "format": "time_series",
           "interval": "",
@@ -2497,9 +2452,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "P90 request time",
       "tooltip": {
         "shared": true,
@@ -2508,9 +2461,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2520,23 +2471,19 @@
           "format": "ms",
           "label": "Time",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:3071",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2583,7 +2530,7 @@
         "h": 11,
         "w": 8,
         "x": 8,
-        "y": 92
+        "y": 100
       },
       "hiddenSeries": false,
       "id": 65,
@@ -2617,6 +2564,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_rq_completed{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "interval": "",
@@ -2626,9 +2574,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Completed requests",
       "tooltip": {
         "shared": true,
@@ -2637,9 +2583,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2649,23 +2593,18 @@
           "format": "short",
           "label": "RPM",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:3071",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2736,7 +2675,7 @@
         "h": 11,
         "w": 8,
         "x": 16,
-        "y": 92
+        "y": 100
       },
       "hiddenSeries": false,
       "id": 67,
@@ -2772,6 +2711,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_rq_cancelled{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "interval": "",
@@ -2780,6 +2720,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_rq_timeout{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "hide": false,
@@ -2790,9 +2731,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Closed requests",
       "tooltip": {
         "shared": true,
@@ -2801,9 +2740,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2813,23 +2750,19 @@
           "format": "short",
           "label": "Number of requests",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:3071",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -2876,7 +2809,7 @@
         "h": 11,
         "w": 8,
         "x": 0,
-        "y": 103
+        "y": 111
       },
       "hiddenSeries": false,
       "id": 68,
@@ -2910,6 +2843,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_cx_active{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "interval": "",
@@ -2919,9 +2853,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Active connections",
       "tooltip": {
         "shared": true,
@@ -2930,9 +2862,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -2942,23 +2872,18 @@
           "format": "short",
           "label": "Number of connections",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:3071",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -3005,7 +2930,7 @@
         "h": 11,
         "w": 8,
         "x": 8,
-        "y": 103
+        "y": 111
       },
       "hiddenSeries": false,
       "id": 70,
@@ -3039,6 +2964,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "histogram_quantile(0.90, sum(rate(envoy_cluster_upstream_cx_length_ms_bucket{}[$__rate_interval])) by (envoy_cluster_name, le))",
           "format": "time_series",
           "interval": "",
@@ -3048,9 +2974,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "P90 Connection length",
       "tooltip": {
         "shared": true,
@@ -3059,9 +2983,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -3071,23 +2993,19 @@
           "format": "ms",
           "label": "Time",
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         },
         {
           "$$hashKey": "object:3071",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     },
     {
@@ -3254,7 +3172,7 @@
         "h": 11,
         "w": 8,
         "x": 16,
-        "y": 103
+        "y": 111
       },
       "hiddenSeries": false,
       "id": 71,
@@ -3290,6 +3208,7 @@
       "steppedLine": false,
       "targets": [
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_cx_connect_timeout{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "interval": "",
@@ -3298,6 +3217,7 @@
           "refId": "A"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_cx_idle_timeout{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "hide": false,
@@ -3307,6 +3227,7 @@
           "refId": "B"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_cx_max_duration_reached{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "hide": false,
@@ -3316,6 +3237,7 @@
           "refId": "C"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_cx_destroy_local{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "hide": false,
@@ -3325,6 +3247,7 @@
           "refId": "D"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_cx_destroy_remote{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "hide": false,
@@ -3334,6 +3257,7 @@
           "refId": "E"
         },
         {
+          "datasource": "${DS_PROMETHEUS}",
           "expr": "sum(rate(envoy_cluster_upstream_cx_max_requests{}[$__rate_interval])) by (envoy_cluster_name)",
           "format": "time_series",
           "hide": false,
@@ -3344,9 +3268,7 @@
         }
       ],
       "thresholds": [],
-      "timeFrom": null,
       "timeRegions": [],
-      "timeShift": null,
       "title": "Closed connections",
       "tooltip": {
         "shared": true,
@@ -3355,9 +3277,7 @@
       },
       "type": "graph",
       "xaxis": {
-        "buckets": null,
         "mode": "time",
-        "name": null,
         "show": true,
         "values": []
       },
@@ -3367,28 +3287,24 @@
           "format": "short",
           "label": "Number of connections",
           "logBase": 1,
-          "max": null,
-          "min": null,
           "show": true
         },
         {
           "$$hashKey": "object:3071",
           "format": "short",
-          "label": null,
           "logBase": 1,
-          "max": null,
           "min": "0",
           "show": true
         }
       ],
       "yaxis": {
-        "align": false,
-        "alignLevel": null
+        "align": false
       }
     }
   ],
   "refresh": "5s",
-  "schemaVersion": 27,
+  "revision": 1,
+  "schemaVersion": 38,
   "style": "dark",
   "tags": [
     "ambassador"
@@ -3396,7 +3312,6 @@
   "templating": {
     "list": [
       {
-        "allValue": null,
         "current": {
           "selected": true,
           "text": [
@@ -3408,8 +3323,6 @@
         },
         "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(ambassador_diagnostics_info, namespace)",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Namespace",
@@ -3425,16 +3338,13 @@
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
       },
       {
-        "allValue": null,
         "current": {
           "selected": true,
-          "tags": [],
           "text": [
             "All"
           ],
@@ -3444,8 +3354,6 @@
         },
         "datasource": "${DS_PROMETHEUS}",
         "definition": "label_values(ambassador_diagnostics_info{namespace=\"$namespace\"}, pod)",
-        "description": null,
-        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Pod",
@@ -3461,7 +3369,6 @@
         "skipUrlSync": false,
         "sort": 5,
         "tagValuesQuery": "",
-        "tags": [],
         "tagsQuery": "",
         "type": "query",
         "useTags": false
@@ -3499,6 +3406,7 @@
   },
   "timezone": "",
   "title": "Ambassador Edge Stack",
-  "version": 23,
-  "description": "Ambassador Edge Stack dashboard for Prometheus"
+  "uid": "AJieHz4Mz",
+  "version": 2,
+  "weekStart": ""
 }


### PR DESCRIPTION
This PR adds 4 new panels to the dashboard for the new Web Application Firewalls feature. The first commit, `40a355f45d022b8b870337919e2e68f5674fe878` is the result of importing the existing json into Grafana, and then fixing the indenting. Grafana added and renamed a couple of fields, but there is no change in behaviour as a result of this I checked the diffs for the things Grafana updated/converted to make sure they were sane.

I split out the second commit to make reviewing the actual additions easier since the github diff viewer is hard to follow when changing the indentation of a whole file.

Here is a screenshot of the new panels:
![Screenshot from 2023-06-14 17-01-42](https://github.com/alexgervais/ambassador-grafana/assets/22459179/282cc878-eca2-47ab-829c-68f19060890b)

For the denials, I added two lines since we can deny a request or the response from the upstream service. I figured this would help with debugging where requests are being dropped. Same with the processing time from the waf. The response processing should almost always be a lot faster than the request since there are fewer things to check and it's less common to have rules processing parts of the response.


